### PR TITLE
Remove bash from the home

### DIFF
--- a/bash/i_want_go_home.sh
+++ b/bash/i_want_go_home.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
 
-cd $HOME
 echo "집에 가고 싶다"
 exec bash


### PR DESCRIPTION
bash does not have a visa to enter $HOME. They're deported.

Fixes #13.